### PR TITLE
🐛   EmbedDescription should update if empty, not if populated.

### DIFF
--- a/src/extensions/Embeddable.php
+++ b/src/extensions/Embeddable.php
@@ -157,7 +157,7 @@ class Embeddable extends DataExtension
             if ($owner->EmbedTitle == '') {
                 $owner->EmbedTitle = $embed->Title;
             }
-            if (!$owner->EmbedDescription == '') {
+            if ($owner->EmbedDescription == '') {
                 $owner->EmbedDescription = $embed->Description;
             }
             $changes = $owner->getChangedFields();


### PR DESCRIPTION
The existing code discards any user-entered EmbedDescription and pulls in the embed origin's description every time.  It should do the opposite - pull in the embed origin's description if the object's description is empty.  This should fix that.