### PR TITLE
FIX: Vimeo image fail validation check

### DIFF
--- a/src/extensions/Embeddable.php
+++ b/src/extensions/Embeddable.php
@@ -153,7 +153,10 @@ class Embeddable extends DataExtension
     {
         $owner = $this->owner;
         if ($sourceURL = $owner->EmbedSourceURL) {
-            $embed = Embed::create($sourceURL);
+            $config = [
+                'choose_bigger_image' => true,
+            ];
+            $embed = Embed::create($sourceURL, $config);
             if ($owner->EmbedTitle == '') {
                 $owner->EmbedTitle = $embed->Title;
             }


### PR DESCRIPTION
Unless a larger image is requested, Vimeo returns a thumbnail that has no file extension.