### PR TITLE
Fix to handle source images with queries

### DIFF
--- a/src/extensions/Embeddable.php
+++ b/src/extensions/Embeddable.php
@@ -172,7 +172,7 @@ class Embeddable extends DataExtension
                     $fileExplode = explode('.', $embed->Image);
                     $fileExtensionExplode = explode('?', end($fileExplode));
                     $fileExtension = $fileExtensionExplode[0];
-                    $fileExtensionQuery = $fileExtensionExplode[0];
+                    $fileExtensionQuery = $fileExtensionExplode[1];
                     $fileName = Convert::raw2url($owner->obj('EmbedTitle')->LimitCharacters(55)) . '.' . $fileExtension;
                     $parentFolder = Folder::find_or_make($owner->EmbedFolder);
 

--- a/src/extensions/Embeddable.php
+++ b/src/extensions/Embeddable.php
@@ -170,7 +170,9 @@ class Embeddable extends DataExtension
                 if ($owner->EmbedSourceImageURL != $embed->Image) {
                     $owner->EmbedSourceImageURL = $embed->Image;
                     $fileExplode = explode('.', $embed->Image);
-                    $fileExtension = end($fileExplode);
+                    $fileExtensionExplode = explode('?', end($fileExplode));
+                    $fileExtension = $fileExtensionExplode[0];
+                    $fileExtensionQuery = $fileExtensionExplode[0];
                     $fileName = Convert::raw2url($owner->obj('EmbedTitle')->LimitCharacters(55)) . '.' . $fileExtension;
                     $parentFolder = Folder::find_or_make($owner->EmbedFolder);
 


### PR DESCRIPTION
oEmbed objects that return image URLs with query parameters fail file extension validation. This fix separates extension and query.